### PR TITLE
Support passing arguments to command

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,9 +21,11 @@ type Config struct {
 // PropValue is the value to match against (suffix match)
 // Action the udev "action" to filter on (add, remove, change, online, offline)
 // Command is the name of your script/program to run
+// Args is a list of arguments to pass to the script/program
 // Subsystem is used to filter udev events monitored
 type rule struct {
 	PropName, PropValue, Command, Action, Subsystem string
+	Args                                            []string
 	limiter                                         int32
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io/ioutil"
 	"log"
+	"reflect"
 	"testing"
 )
 
@@ -21,6 +22,10 @@ func TestConfigLoad(t *testing.T) {
 	if conf.Rules[1].PropName != "ID_MODEL" {
 		t.Error("Bad Rules field, got: ", conf.Rules[1].PropName,
 			"want: HID_NAME")
+	}
+	if !reflect.DeepEqual(conf.Rules[1].Args, []string{"set-default-sink", "Audioengine_D1"}) {
+		t.Error("Bad Args field, got: ", conf.Rules[1].Args,
+			"want: [set-default-sink, Audioengine_D1]")
 	}
 }
 

--- a/example-config.toml
+++ b/example-config.toml
@@ -10,6 +10,7 @@ ScriptPath = "${HOME}/bin/udev.d"
 # PropValue is the value to match against (suffix match)
 # Action the udev "action" to filter on (add, remove, change, online, offline)
 # Command is the name of your script/program to run
+# Args is a list of arguments to pass to the script/program
 
 # Can watch for external display plug events and run xrandr scripts
 [[Rules]]
@@ -26,7 +27,8 @@ Subsystem = "sound"
 PropName  = "ID_MODEL"
 PropValue = "Audioengine_D1"
 Action    = "change"
-Command   = "set-default-sink"
+Command   = "pactl"
+Args      = ["set-default-sink", "Audioengine_D1"]
 
 # Run xinput configuration settings for devices
 [[Rules]]

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func commandRunners(conf *Config) chan<- rule {
 					cmd = filepath.Join(os.ExpandEnv(conf.ScriptPath),
 						r.Command)
 				}
-				out, err := exec.Command(cmd).CombinedOutput()
+				out, err := exec.Command(cmd, r.Args...).CombinedOutput()
 				if err != nil {
 					log.Println(err)
 				}


### PR DESCRIPTION
This makes it possible to supply arguments/flags to commands, avoiding the need for wrapper scripts for simple tasks.